### PR TITLE
Added a Similar Query Feature to the Get Command

### DIFF
--- a/code_bot.py
+++ b/code_bot.py
@@ -106,8 +106,10 @@ async def _get(ctx, index: int):
     similar_queries = queries[index].get("similar_queries", [])[:3]
     if similar_queries:
         embed.add_field(
-            name=f"Similar queries:",
-            value="\n".join(f"• ID-{i}: {queries[i]['query']}" for i in similar_queries),
+            name=f"Similar Queries",
+            value="\n".join(f"• ID-{i}: {create_md_link(queries[i].get('resource'), queries[i].get('query'))}" 
+                for i in similar_queries
+            ),
             inline=True
         )
 

--- a/code_bot.py
+++ b/code_bot.py
@@ -12,7 +12,7 @@ from discord_slash.utils.manage_commands import create_option
 from dotenv import load_dotenv
 
 
-__version__ = "0.1.1"
+__version__ = "0.2.0"
 
 
 # Global variables

--- a/code_bot.py
+++ b/code_bot.py
@@ -28,6 +28,7 @@ slash = SlashCommand(client, sync_commands=True)
 load_dotenv()
 queries = json.load(open("queries.json"))
 keyword_mapping = generate_keyword_mapping(queries)
+generate_similar_queries(queries, keyword_mapping)
 
 
 # Discord bot code
@@ -102,6 +103,13 @@ async def _get(ctx, index: int):
         value=queries[index].get("response"),
         inline=False
     )
+    similar_queries = queries[index].get("similar_queries", [])[:3]
+    if similar_queries:
+        embed.add_field(
+            name=f"Similar queries:",
+            value="\n".join(f"• ID-{i}: {queries[i]['query']}" for i in similar_queries),
+            inline=True
+        )
 
     await ctx.send(embed=embed)
 

--- a/code_bot_utils.py
+++ b/code_bot_utils.py
@@ -60,6 +60,21 @@ def search(keyword_to_queries: dict, keywords: list) -> list:
     return best_matches
 
 
+def generate_similar_queries(queries: list, keyword_to_queries: dict) -> None:
+    """
+    Generates a list of similar queries.
+
+    :param queries: a list of queries
+    :param keyword_to_queries: a mapping of keywords to query indices
+    """
+    for i, query in enumerate(queries):
+        if i > 0:
+            keywords = generate_keywords(query["query"])
+            top_ids = search(keyword_to_queries, keywords)
+            top_ids.remove(i)
+            query["similar_queries"] = top_ids
+
+
 def create_md_link(url: string, text: string) -> string:
     """
     Creates a markdown link.

--- a/test_code_bot.py
+++ b/test_code_bot.py
@@ -34,3 +34,8 @@ def test_generate_keyword_mapping():
     }
     keyword_mapping = generate_keyword_mapping([test_query])
     assert keyword_mapping == expected_mapping
+
+def test_generate_similar_queries():
+    generate_similar_queries(queries, keyword_mapping)
+    print(queries)
+    #assert similar_queries == expected_similar_queries

--- a/test_code_bot.py
+++ b/test_code_bot.py
@@ -37,5 +37,4 @@ def test_generate_keyword_mapping():
 
 def test_generate_similar_queries():
     generate_similar_queries(queries, keyword_mapping)
-    print(queries)
-    #assert similar_queries == expected_similar_queries
+    assert 1 not in queries[1]["similar_queries"] 


### PR DESCRIPTION
The user should see related queries now when they call the get command. Here's an example:

## CS Query Bot v0.1.1: Answer to ID-8

**What is unit testing?**

Unit testing is a specific form of program testing where the focus is on a small unit of the program, usually a single method. A common unit testing framework in Java is JUnit.

**Similar Queries**

• ID-4: What is testing?
• ID-7: What is JUnit?
• ID-5: What is debugging?


