### PR TITLE
Added the Ability to Load a JSON File Remotely

### DIFF
--- a/.env.test_type_0
+++ b/.env.test_type_0
@@ -1,0 +1,1 @@
+KNOWLEDGE_PATH="https://raw.githubusercontent.com/TheRenegadeCoder/cs-query-bot/main/queries.json"

--- a/.env.test_type_1
+++ b/.env.test_type_1
@@ -1,0 +1,1 @@
+KNOWLEDGE_PATH="queries.json"

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ If you'd like to use this bot in your own server, start by cloning/forking this 
 DISCORD_TOKEN=[insert token here]
 ```
 
+If you'd like to include your own knowledge base, you can do so by also creating a KNOWLEDGE_PATH environment variable in your .env file. This should point to a local file or a remote URL. Otherwise, the bot will use the queries.json file, which is designed specifically for a course I am teaching.
+
+```env
+KNOWLEDGE_PATH=[insert path here]
+```
+
 After that, you'll want to install all requirements. Luckily, I've included a requirements.txt file. You can use the following code to install all requirements:
 
 ```shell

--- a/code_bot.py
+++ b/code_bot.py
@@ -25,10 +25,7 @@ client = commands.Bot(
     status=discord.Status.idle
 )
 slash = SlashCommand(client, sync_commands=True)
-load_dotenv()
-_, queries = load_knowledge()
-keyword_mapping = generate_keyword_mapping(queries)
-generate_similar_queries(queries, keyword_mapping)
+queries, keyword_mapping = refresh_knowledge()
 
 
 # Discord bot code
@@ -114,6 +111,24 @@ async def _get(ctx, index: int):
         )
 
     await ctx.send(embed=embed)
+
+
+@slash.slash(
+    name="refresh",
+    description="Refreshes the bot's knowledge base.",
+)
+async def _refresh(ctx):
+    """
+    Refreshes the bot's knowledge base.
+
+    :param ctx: the context to send messages to
+    :return: None
+    """
+    new_queries, new_keyword_mapping = refresh_knowledge()
+    global queries, keyword_mapping
+    diff = [x for x in new_queries if x not in queries]
+    queries, keyword_mapping = new_queries, new_keyword_mapping
+    await ctx.send(f"{len(diff)} queries modified and/or added.")
 
 
 client.run(os.environ.get("DISCORD_TOKEN"))

--- a/code_bot.py
+++ b/code_bot.py
@@ -26,7 +26,7 @@ client = commands.Bot(
 )
 slash = SlashCommand(client, sync_commands=True)
 load_dotenv()
-queries = load_knowledge()
+_, queries = load_knowledge()
 keyword_mapping = generate_keyword_mapping(queries)
 generate_similar_queries(queries, keyword_mapping)
 

--- a/code_bot.py
+++ b/code_bot.py
@@ -26,7 +26,7 @@ client = commands.Bot(
 )
 slash = SlashCommand(client, sync_commands=True)
 load_dotenv()
-queries = json.load(open("queries.json"))
+queries = load_knowledge()
 keyword_mapping = generate_keyword_mapping(queries)
 generate_similar_queries(queries, keyword_mapping)
 

--- a/code_bot.py
+++ b/code_bot.py
@@ -12,7 +12,7 @@ from discord_slash.utils.manage_commands import create_option
 from dotenv import load_dotenv
 
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 
 # Global variables

--- a/code_bot_utils.py
+++ b/code_bot_utils.py
@@ -1,6 +1,8 @@
 import string
 import json
 import os
+from urllib.request import urlopen
+
 
 def generate_keyword_mapping(queries: list) -> dict:
     """
@@ -90,14 +92,21 @@ def create_md_link(url: string, text: string) -> string:
     return text
 
 
-def load_knowledge() -> dict:
+def load_knowledge() -> tuple[int, dict]:
     """
     Loads the bot's knowledge database. Prioritizes the
     KNOWLEDGE_PATH environment variable. KNOWLEDGE_PATH
     can be set to a local file or a remote URL. Otherwise,
     uses the local queries file. 
+
+    :return: a tuple of the type of knowledge database and the
+        knowledge database (0 for remote, 1 for local, 2 for default)
     """
     if path := os.environ.get("KNOWLEDGE_PATH"):
-        return json.load(open(path))
+        try:
+            data = urlopen(path).read().decode("utf-8")
+            return 0, json.loads(data)
+        except:
+            return 1, json.load(open(path))
     else:
-        return json.load(open("queries.json"))
+        return 2, json.load(open("queries.json"))

--- a/code_bot_utils.py
+++ b/code_bot_utils.py
@@ -3,6 +3,8 @@ import json
 import os
 from urllib.request import urlopen
 
+from dotenv import load_dotenv
+
 
 def generate_keyword_mapping(queries: list) -> dict:
     """
@@ -92,7 +94,7 @@ def create_md_link(url: string, text: string) -> string:
     return text
 
 
-def load_knowledge() -> tuple[int, dict]:
+def load_knowledge() -> tuple[int, list]:
     """
     Loads the bot's knowledge database. Prioritizes the
     KNOWLEDGE_PATH environment variable. KNOWLEDGE_PATH
@@ -110,3 +112,20 @@ def load_knowledge() -> tuple[int, dict]:
             return 1, json.load(open(path))
     else:
         return 2, json.load(open("queries.json"))
+
+
+def refresh_knowledge() -> tuple[list, dict]:
+    """
+    Generates useful information from the knowledge database. 
+    Useful when initializing the bot or when the knowledge
+    database has been updated.
+
+    :return: a tuple of the knowledge database and a mapping of
+        keywords to query indices
+    """
+    load_dotenv()
+    _, queries = load_knowledge()
+    keyword_mapping = generate_keyword_mapping(queries)
+    generate_similar_queries(queries, keyword_mapping)
+    return queries, keyword_mapping
+

--- a/code_bot_utils.py
+++ b/code_bot_utils.py
@@ -1,4 +1,6 @@
 import string
+import json
+import os
 
 def generate_keyword_mapping(queries: list) -> dict:
     """
@@ -86,3 +88,16 @@ def create_md_link(url: string, text: string) -> string:
     if url:
         return f"[{text}]({url})"
     return text
+
+
+def load_knowledge() -> dict:
+    """
+    Loads the bot's knowledge database. Prioritizes the
+    KNOWLEDGE_PATH environment variable. KNOWLEDGE_PATH
+    can be set to a local file or a remote URL. Otherwise,
+    uses the local queries file. 
+    """
+    if path := os.environ.get("KNOWLEDGE_PATH"):
+        return json.load(open(path))
+    else:
+        return json.load(open("queries.json"))

--- a/readme.py
+++ b/readme.py
@@ -32,6 +32,20 @@ doc.add_code(
 
 doc.add_paragraph(
     """
+    If you'd like to include your own knowledge base, you can do so by also creating
+    a KNOWLEDGE_PATH environment variable in your .env file. This should point to a 
+    local file or a remote URL. Otherwise, the bot will use the queries.json file,
+    which is designed specifically for a course I am teaching.
+    """
+)
+
+doc.add_code(
+    "KNOWLEDGE_PATH=[insert path here]",
+    "env"
+)
+
+doc.add_paragraph(
+    """
     After that, you'll want to install all requirements. Luckily, I've included a
     requirements.txt file. You can use the following code to install all
     requirements:

--- a/test_code_bot.py
+++ b/test_code_bot.py
@@ -45,6 +45,7 @@ def test_load_knowledge_type_1():
     actualType, actualKnowledge = load_knowledge()
     expectedType = 1
     expectedKnowledge = json.load(open("queries.json"))
+    os.environ.pop("KNOWLEDGE_PATH")
     assert expectedType == actualType
     assert expectedKnowledge == actualKnowledge
 

--- a/test_code_bot.py
+++ b/test_code_bot.py
@@ -38,3 +38,10 @@ def test_generate_keyword_mapping():
 def test_generate_similar_queries():
     generate_similar_queries(queries, keyword_mapping)
     assert 1 not in queries[1]["similar_queries"] 
+
+def test_load_knowledge_type_2():
+    actualType, actualKnowledge = load_knowledge()
+    expectedType = 2
+    expectedKnowledge = json.load(open("queries.json"))
+    assert expectedType == actualType
+    assert expectedKnowledge == actualKnowledge

--- a/test_code_bot.py
+++ b/test_code_bot.py
@@ -1,5 +1,6 @@
 import json
 from code_bot_utils import *
+from dotenv import load_dotenv
 
 queries = json.load(open("queries.json"))
 keyword_mapping = generate_keyword_mapping(queries)
@@ -40,6 +41,7 @@ def test_generate_similar_queries():
     assert 1 not in queries[1]["similar_queries"] 
 
 def test_load_knowledge_type_1():
+    load_dotenv(dotenv_path=".env.test_type_1")
     actualType, actualKnowledge = load_knowledge()
     expectedType = 1
     expectedKnowledge = json.load(open("queries.json"))

--- a/test_code_bot.py
+++ b/test_code_bot.py
@@ -40,6 +40,18 @@ def test_generate_similar_queries():
     generate_similar_queries(queries, keyword_mapping)
     assert 1 not in queries[1]["similar_queries"] 
 
+def test_load_knowledge_type_0():
+    load_dotenv(dotenv_path=".env.test_type_0")
+    actualType, actualKnowledge = load_knowledge()
+    expectedType = 0
+    data = urlopen("https://raw.githubusercontent.com/TheRenegadeCoder/cs-query-bot/main/queries.json") \
+        .read() \
+        .decode("utf-8")
+    expectedKnowledge = json.loads(data)
+    os.environ.pop("KNOWLEDGE_PATH")
+    assert expectedType == actualType
+    assert expectedKnowledge == actualKnowledge
+
 def test_load_knowledge_type_1():
     load_dotenv(dotenv_path=".env.test_type_1")
     actualType, actualKnowledge = load_knowledge()

--- a/test_code_bot.py
+++ b/test_code_bot.py
@@ -39,6 +39,13 @@ def test_generate_similar_queries():
     generate_similar_queries(queries, keyword_mapping)
     assert 1 not in queries[1]["similar_queries"] 
 
+def test_load_knowledge_type_1():
+    actualType, actualKnowledge = load_knowledge()
+    expectedType = 1
+    expectedKnowledge = json.load(open("queries.json"))
+    assert expectedType == actualType
+    assert expectedKnowledge == actualKnowledge
+
 def test_load_knowledge_type_2():
     actualType, actualKnowledge = load_knowledge()
     expectedType = 2


### PR DESCRIPTION
This feature has been added to the .env file under the KNOWLEDGE_PATH variable. A local path or remote URL can be used to override the knowledge database. Eventually, I might make a folder for different sets of queries. Could be fun!